### PR TITLE
various updates to nr-prose examples and logging

### DIFF
--- a/examples/nr-prose-discovery-l3-relay-selection.cc
+++ b/examples/nr-prose-discovery-l3-relay-selection.cc
@@ -463,7 +463,7 @@ main(int argc, char* argv[])
     bwp0->m_channelBandwidth = bandwidthCc0Bpw0;
     bwp0->m_lowerFrequency = bwp0->m_centralFrequency - bwp0->m_channelBandwidth / 2;
     bwp0->m_higherFrequency = bwp0->m_centralFrequency + bwp0->m_channelBandwidth / 2;
-    bwp0->m_scenario = BandwidthPartInfo::Scenario::UMa;
+    bwp0->m_scenario = BandwidthPartInfo::Scenario::UMa_LoS;
 
     cc0->AddBwp(std::move(bwp0));
 
@@ -473,7 +473,7 @@ main(int argc, char* argv[])
     bwp1->m_channelBandwidth = bandwidthCc0Bpw1;
     bwp1->m_lowerFrequency = bwp1->m_centralFrequency - bwp1->m_channelBandwidth / 2;
     bwp1->m_higherFrequency = bwp1->m_centralFrequency + bwp1->m_channelBandwidth / 2;
-    bwp1->m_scenario = BandwidthPartInfo::Scenario::RMa;
+    bwp1->m_scenario = BandwidthPartInfo::Scenario::RMa_LoS;
 
     cc0->AddBwp(std::move(bwp1));
 

--- a/examples/nr-prose-discovery-l3-relay-selection.cc
+++ b/examples/nr-prose-discovery-l3-relay-selection.cc
@@ -305,7 +305,9 @@ main(int argc, char* argv[])
     /*
      * Fix the random streams
      */
-    uint64_t stream = 1;
+    int64_t stream = 1;
+    const uint64_t streamIncrement = 1000;
+    // Use the first few stream numbers for node position
     Ptr<UniformRandomVariable> m_uniformRandomVariablePositionX =
         CreateObject<UniformRandomVariable>();
     m_uniformRandomVariablePositionX->SetStream(stream++);
@@ -327,6 +329,11 @@ main(int argc, char* argv[])
     }
     mobilityRemotes.SetPositionAllocator(positionAllocRemotes);
     mobilityRemotes.Install(remoteUeNodes);
+    stream += streamIncrement;
+    for (uint32_t i = 0; i < remoteUeNodes.GetN(); i++)
+    {
+        remoteUeNodes.Get(i)->GetObject<RandomWalk2dMobilityModel>()->AssignStreams(stream);
+    }
 
     MobilityHelper mobilityRelays;
     mobilityRelays.SetMobilityModel("ns3::RandomWalk2dMobilityModel",
@@ -341,6 +348,11 @@ main(int argc, char* argv[])
     }
     mobilityRelays.SetPositionAllocator(positionAllocRelays);
     mobilityRelays.Install(relayUeNodes);
+    stream += streamIncrement;
+    for (uint32_t i = 0; i < relayUeNodes.GetN(); i++)
+    {
+        relayUeNodes.Get(i)->GetObject<RandomWalk2dMobilityModel>()->AssignStreams(stream);
+    }
 
     for (uint32_t i = 0; i < gNbNodes.GetN(); ++i)
     {
@@ -742,11 +754,16 @@ main(int argc, char* argv[])
 
     /****************************** End SL Configuration ***********************/
 
-    stream += nrHelper->AssignStreams(enbNetDev, stream);
-    stream += nrHelper->AssignStreams(relayUeNetDev, stream);
-    stream += nrSlHelper->AssignStreams(relayUeNetDev, stream);
-    stream += nrHelper->AssignStreams(remoteUeNetDev, stream);
-    stream += nrSlHelper->AssignStreams(remoteUeNetDev, stream);
+    stream += streamIncrement;
+    nrHelper->AssignStreams(enbNetDev, stream);
+    stream += streamIncrement;
+    nrHelper->AssignStreams(relayUeNetDev, stream);
+    stream += streamIncrement;
+    nrSlHelper->AssignStreams(relayUeNetDev, stream);
+    stream += streamIncrement;
+    nrHelper->AssignStreams(remoteUeNetDev, stream);
+    stream += streamIncrement;
+    nrSlHelper->AssignStreams(remoteUeNetDev, stream);
 
     // create the internet and install the IP stack on the UEs
     // get SGW/PGW and create a single RemoteHost

--- a/examples/nr-prose-discovery-l3-relay.cc
+++ b/examples/nr-prose-discovery-l3-relay.cc
@@ -456,8 +456,10 @@ main(int argc, char* argv[])
      * Fix the random streams
      */
     int64_t stream = 1;
-    stream += nrHelper->AssignStreams(ueVoiceNetDev, stream);
-    stream += nrSlHelper->AssignStreams(ueVoiceNetDev, stream);
+    const uint64_t streamIncrement = 1000;
+    nrHelper->AssignStreams(ueVoiceNetDev, stream);
+    stream += streamIncrement;
+    nrSlHelper->AssignStreams(ueVoiceNetDev, stream);
 
     /*
      * Configure the IPv4 stack

--- a/examples/nr-prose-discovery.cc
+++ b/examples/nr-prose-discovery.cc
@@ -458,8 +458,10 @@ main(int argc, char* argv[])
      * Fix the random streams
      */
     int64_t stream = 1;
-    stream += nrHelper->AssignStreams(ueVoiceNetDev, stream);
-    stream += nrSlHelper->AssignStreams(ueVoiceNetDev, stream);
+    const uint64_t streamIncrement = 1000;
+    nrHelper->AssignStreams(ueVoiceNetDev, stream);
+    stream += streamIncrement;
+    nrSlHelper->AssignStreams(ueVoiceNetDev, stream);
 
     /*
      * Configure the IPv4 stack

--- a/examples/nr-prose-l3-relay-mcptt.cc
+++ b/examples/nr-prose-l3-relay-mcptt.cc
@@ -854,6 +854,7 @@ main(int argc, char* argv[])
     bwp0->m_channelBandwidth = bandwidthCc0Bpw0;
     bwp0->m_lowerFrequency = bwp0->m_centralFrequency - bwp0->m_channelBandwidth / 2;
     bwp0->m_higherFrequency = bwp0->m_centralFrequency + bwp0->m_channelBandwidth / 2;
+    bwp0->m_scenario = BandwidthPartInfo::Scenario::RMa_LoS;
 
     cc0->AddBwp(std::move(bwp0));
 
@@ -863,6 +864,7 @@ main(int argc, char* argv[])
     bwp1->m_channelBandwidth = bandwidthCc0Bpw1;
     bwp1->m_lowerFrequency = bwp1->m_centralFrequency - bwp1->m_channelBandwidth / 2;
     bwp1->m_higherFrequency = bwp1->m_centralFrequency + bwp1->m_channelBandwidth / 2;
+    bwp1->m_scenario = BandwidthPartInfo::Scenario::RMa_LoS;
 
     cc0->AddBwp(std::move(bwp1));
 

--- a/examples/nr-prose-l3-relay-mcptt.cc
+++ b/examples/nr-prose-l3-relay-mcptt.cc
@@ -1122,12 +1122,18 @@ main(int argc, char* argv[])
 
     // Set random streams
     int64_t randomStream = 1;
-    randomStream += nrHelper->AssignStreams(enbNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(inNetUeNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(relayUeNetDev, randomStream);
-    randomStream += nrSlHelper->AssignStreams(relayUeNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(remoteUeNetDev, randomStream);
-    randomStream += nrSlHelper->AssignStreams(remoteUeNetDev, randomStream);
+    const uint64_t streamIncrement = 1000;
+    nrHelper->AssignStreams(enbNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(inNetUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(relayUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrSlHelper->AssignStreams(relayUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(remoteUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrSlHelper->AssignStreams(remoteUeNetDev, randomStream);
 
     // create the internet and install the IP stack on the UEs
     // get SGW/PGW
@@ -1922,6 +1928,18 @@ main(int argc, char* argv[])
     allClientApps.Stop(simTime - Seconds(1.0));
     serverApps.Start(timeStartTraffic - Seconds(0.6));
     serverApps.Stop(simTime - Seconds(1.0));
+
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(gNbNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(inNetUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(relayUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(remoteUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(remoteHostContainer, randomStream);
+
     /******************** End Application configuration ************************/
 
     /**************** MCPTT metrics tracing ************************************/

--- a/examples/nr-prose-l3-relay-on-off.cc
+++ b/examples/nr-prose-l3-relay-on-off.cc
@@ -1097,12 +1097,18 @@ main(int argc, char* argv[])
 
     // Set random streams
     int64_t randomStream = 1;
-    randomStream += nrHelper->AssignStreams(enbNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(inNetUeNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(relayUeNetDev, randomStream);
-    randomStream += nrSlHelper->AssignStreams(relayUeNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(remoteUeNetDev, randomStream);
-    randomStream += nrSlHelper->AssignStreams(remoteUeNetDev, randomStream);
+    const uint64_t streamIncrement = 1000;
+    nrHelper->AssignStreams(enbNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(inNetUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(relayUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrSlHelper->AssignStreams(relayUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(remoteUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrSlHelper->AssignStreams(remoteUeNetDev, randomStream);
 
     // create the internet and install the IP stack on the UEs
     // get SGW/PGW and create a single RemoteHost
@@ -1400,6 +1406,8 @@ main(int argc, char* argv[])
     // Random variable to randomize a bit start times of the client applications
     // to avoid simulation artifacts of all the TX UEs transmitting at the same time.
     Ptr<UniformRandomVariable> startTimeRnd = CreateObject<UniformRandomVariable>();
+    randomStream += streamIncrement;
+    startTimeRnd->SetStream(randomStream);
     startTimeRnd->SetAttribute("Min", DoubleValue(0));
     startTimeRnd->SetAttribute("Max", DoubleValue(2.0)); // seconds
     std::string dataRateString = std::to_string(onOffDataRate) + "kb/s";
@@ -1457,17 +1465,17 @@ main(int argc, char* argv[])
         //-Server on UE
         PacketSinkHelper dlpacketSinkHelper("ns3::UdpSocketFactory",
                                             InetSocketAddress(Ipv4Address::GetAny(), dlPort));
-        ApplicationContainer dlSeverApp = dlpacketSinkHelper.Install(inNetUeNodes.Get(inIdx));
-        serverApps.Add(dlSeverApp);
+        ApplicationContainer dlServerApp = dlpacketSinkHelper.Install(inNetUeNodes.Get(inIdx));
+        serverApps.Add(dlServerApp);
 
 #ifdef HAS_NETSIMULYZER
         auto dlRxTput = CreateObject<netsimulyzer::ThroughputSink>(
             orchestrator,
             "Throughput - InNet UE - Rx - DL - Node " + std::to_string(nodeId));
         dlRxTput->GetSeries()->SetAttribute("Color", GetNextColor());
-        dlSeverApp.Get(0)->TraceConnect("RxWithSeqTsSize",
-                                        "rx",
-                                        MakeBoundCallback(&PacketTraceNetSimulyzer, dlRxTput));
+        dlServerApp.Get(0)->TraceConnect("RxWithSeqTsSize",
+                                         "rx",
+                                         MakeBoundCallback(&PacketTraceNetSimulyzer, dlRxTput));
         dlUeTputCollection->Add(dlRxTput->GetSeries());
         dlRxTputCollection->Add(dlRxTput->GetSeries());
 
@@ -1479,17 +1487,17 @@ main(int argc, char* argv[])
         dlRxDelay->SetAttribute("Connection", StringValue("None"));
         dlRxDelay->GetXAxis()->SetAttribute("Name", StringValue("Time (s)"));
         dlRxDelay->GetYAxis()->SetAttribute("Name", StringValue("Packet delay (ms)"));
-        dlSeverApp.Get(0)->TraceConnectWithoutContext(
+        dlServerApp.Get(0)->TraceConnectWithoutContext(
             "RxWithSeqTsSize",
             MakeBoundCallback(&RxPacketTraceForDelayNetSimulyzer,
                               dlRxDelay,
-                              dlSeverApp.Get(0)->GetNode(),
+                              dlServerApp.Get(0)->GetNode(),
                               inNetIpv4AddressVector[inIdx]));
-        dlSeverApp.Get(0)->TraceConnectWithoutContext(
+        dlServerApp.Get(0)->TraceConnectWithoutContext(
             "RxWithSeqTsSize",
             MakeBoundCallback(&CdfTraceForDelayNetSimulyzer,
                               dlDelayEcdfInNet,
-                              dlSeverApp.Get(0)->GetNode(),
+                              dlServerApp.Get(0)->GetNode(),
                               inNetIpv4AddressVector[inIdx]));
 #endif
 
@@ -1546,17 +1554,17 @@ main(int argc, char* argv[])
         //-Server on Remtoe Host
         PacketSinkHelper ulPacketSinkHelper("ns3::UdpSocketFactory",
                                             InetSocketAddress(Ipv4Address::GetAny(), ulPort));
-        ApplicationContainer ulSeverApp = ulPacketSinkHelper.Install(remoteHost);
-        serverApps.Add(ulSeverApp);
+        ApplicationContainer ulServerApp = ulPacketSinkHelper.Install(remoteHost);
+        serverApps.Add(ulServerApp);
 
 #ifdef HAS_NETSIMULYZER
         auto ulRxTput = CreateObject<netsimulyzer::ThroughputSink>(
             orchestrator,
             "Throughput - InNet UE - Rx - UL - Node " + std::to_string(nodeId));
         ulRxTput->GetSeries()->SetAttribute("Color", GetNextColor());
-        ulSeverApp.Get(0)->TraceConnect("RxWithSeqTsSize",
-                                        "rx",
-                                        MakeBoundCallback(&PacketTraceNetSimulyzer, ulRxTput));
+        ulServerApp.Get(0)->TraceConnect("RxWithSeqTsSize",
+                                         "rx",
+                                         MakeBoundCallback(&PacketTraceNetSimulyzer, ulRxTput));
         ulUeTputCollection->Add(ulRxTput->GetSeries());
         ulRxTputCollection->Add(ulRxTput->GetSeries());
 
@@ -1568,20 +1576,19 @@ main(int argc, char* argv[])
         ulRxDelay->SetAttribute("Connection", StringValue("None"));
         ulRxDelay->GetXAxis()->SetAttribute("Name", StringValue("Time (s)"));
         ulRxDelay->GetYAxis()->SetAttribute("Name", StringValue("Packet delay (ms)"));
-        ulSeverApp.Get(0)->TraceConnectWithoutContext(
+        ulServerApp.Get(0)->TraceConnectWithoutContext(
             "RxWithSeqTsSize",
             MakeBoundCallback(&RxPacketTraceForDelayNetSimulyzer,
                               ulRxDelay,
-                              ulSeverApp.Get(0)->GetNode(),
+                              ulServerApp.Get(0)->GetNode(),
                               remoteHostAddr));
-        ulSeverApp.Get(0)->TraceConnectWithoutContext(
+        ulServerApp.Get(0)->TraceConnectWithoutContext(
             "RxWithSeqTsSize",
             MakeBoundCallback(&CdfTraceForDelayNetSimulyzer,
                               ulDelayEcdfInNet,
-                              ulSeverApp.Get(0)->GetNode(),
+                              ulServerApp.Get(0)->GetNode(),
                               remoteHostAddr));
 #endif
-
         // UL bearer configuration
         Ptr<EpcTft> tftUl = Create<EpcTft>();
         EpcTft::PacketFilter pfUl;
@@ -1642,17 +1649,17 @@ main(int argc, char* argv[])
         //-Server on UE
         PacketSinkHelper dlpacketSinkHelper("ns3::UdpSocketFactory",
                                             InetSocketAddress(Ipv4Address::GetAny(), dlPort));
-        ApplicationContainer dlSeverApp = dlpacketSinkHelper.Install(remoteUeNodes.Get(rmIdx));
-        serverApps.Add(dlSeverApp);
+        ApplicationContainer dlServerApp = dlpacketSinkHelper.Install(remoteUeNodes.Get(rmIdx));
+        serverApps.Add(dlServerApp);
 
 #ifdef HAS_NETSIMULYZER
         auto dlRxTput = CreateObject<netsimulyzer::ThroughputSink>(
             orchestrator,
             "Throughput - Remote UE - Rx - DL - Node " + std::to_string(nodeId));
         dlRxTput->GetSeries()->SetAttribute("Color", GetNextColor());
-        dlSeverApp.Get(0)->TraceConnect("RxWithSeqTsSize",
-                                        "rx",
-                                        MakeBoundCallback(&PacketTraceNetSimulyzer, dlRxTput));
+        dlServerApp.Get(0)->TraceConnect("RxWithSeqTsSize",
+                                         "rx",
+                                         MakeBoundCallback(&PacketTraceNetSimulyzer, dlRxTput));
         dlUeTputCollection->Add(dlRxTput->GetSeries());
         dlRxTputCollection->Add(dlRxTput->GetSeries());
 
@@ -1664,17 +1671,17 @@ main(int argc, char* argv[])
         dlRxDelay->SetAttribute("Connection", StringValue("None"));
         dlRxDelay->GetXAxis()->SetAttribute("Name", StringValue("Time (s)"));
         dlRxDelay->GetYAxis()->SetAttribute("Name", StringValue("Packet delay (ms)"));
-        dlSeverApp.Get(0)->TraceConnectWithoutContext(
+        dlServerApp.Get(0)->TraceConnectWithoutContext(
             "RxWithSeqTsSize",
             MakeBoundCallback(&RxPacketTraceForDelayNetSimulyzer,
                               dlRxDelay,
-                              dlSeverApp.Get(0)->GetNode(),
+                              dlServerApp.Get(0)->GetNode(),
                               remotesIpv4AddressVector[rmIdx]));
-        dlSeverApp.Get(0)->TraceConnectWithoutContext(
+        dlServerApp.Get(0)->TraceConnectWithoutContext(
             "RxWithSeqTsSize",
             MakeBoundCallback(&CdfTraceForDelayNetSimulyzer,
                               dlDelayEcdfRemotes,
-                              dlSeverApp.Get(0)->GetNode(),
+                              dlServerApp.Get(0)->GetNode(),
                               remotesIpv4AddressVector[rmIdx]));
 #endif
 
@@ -1731,17 +1738,17 @@ main(int argc, char* argv[])
         //-Server on Remote Host
         PacketSinkHelper ulPacketSinkHelper("ns3::UdpSocketFactory",
                                             InetSocketAddress(Ipv4Address::GetAny(), ulPort));
-        ApplicationContainer ulSeverApp = ulPacketSinkHelper.Install(remoteHost);
-        serverApps.Add(ulSeverApp);
+        ApplicationContainer ulServerApp = ulPacketSinkHelper.Install(remoteHost);
+        serverApps.Add(ulServerApp);
 
 #ifdef HAS_NETSIMULYZER
         auto ulRxTput = CreateObject<netsimulyzer::ThroughputSink>(
             orchestrator,
             "Throughput - Remote UE - Rx - UL - Node " + std::to_string(nodeId));
         ulRxTput->GetSeries()->SetAttribute("Color", GetNextColor());
-        ulSeverApp.Get(0)->TraceConnect("RxWithSeqTsSize",
-                                        "rx",
-                                        MakeBoundCallback(&PacketTraceNetSimulyzer, ulRxTput));
+        ulServerApp.Get(0)->TraceConnect("RxWithSeqTsSize",
+                                         "rx",
+                                         MakeBoundCallback(&PacketTraceNetSimulyzer, ulRxTput));
         ulUeTputCollection->Add(ulRxTput->GetSeries());
         ulRxTputCollection->Add(ulRxTput->GetSeries());
 
@@ -1753,17 +1760,17 @@ main(int argc, char* argv[])
         ulRxDelay->SetAttribute("Connection", StringValue("None"));
         ulRxDelay->GetXAxis()->SetAttribute("Name", StringValue("Time (s)"));
         ulRxDelay->GetYAxis()->SetAttribute("Name", StringValue("Packet delay (ms)"));
-        ulSeverApp.Get(0)->TraceConnectWithoutContext(
+        ulServerApp.Get(0)->TraceConnectWithoutContext(
             "RxWithSeqTsSize",
             MakeBoundCallback(&RxPacketTraceForDelayNetSimulyzer,
                               ulRxDelay,
-                              ulSeverApp.Get(0)->GetNode(),
+                              ulServerApp.Get(0)->GetNode(),
                               remoteHostAddr));
-        ulSeverApp.Get(0)->TraceConnectWithoutContext(
+        ulServerApp.Get(0)->TraceConnectWithoutContext(
             "RxWithSeqTsSize",
             MakeBoundCallback(&CdfTraceForDelayNetSimulyzer,
                               ulDelayEcdfRemotes,
-                              ulSeverApp.Get(0)->GetNode(),
+                              ulServerApp.Get(0)->GetNode(),
                               remoteHostAddr));
 #endif
 
@@ -1829,17 +1836,17 @@ main(int argc, char* argv[])
             //-Server in UE
             PacketSinkHelper dlpacketSinkHelper("ns3::UdpSocketFactory",
                                                 InetSocketAddress(Ipv4Address::GetAny(), dlPort));
-            ApplicationContainer dlSeverApp = dlpacketSinkHelper.Install(relayUeNodes.Get(ryIdx));
-            serverApps.Add(dlSeverApp);
+            ApplicationContainer dlServerApp = dlpacketSinkHelper.Install(relayUeNodes.Get(ryIdx));
+            serverApps.Add(dlServerApp);
 
 #ifdef HAS_NETSIMULYZER
             auto dlRxTput = CreateObject<netsimulyzer::ThroughputSink>(
                 orchestrator,
                 "Throughput - Relay UE - Rx - DL - Node " + std::to_string(nodeId));
             dlRxTput->GetSeries()->SetAttribute("Color", GetNextColor());
-            dlSeverApp.Get(0)->TraceConnect("RxWithSeqTsSize",
-                                            "rx",
-                                            MakeBoundCallback(&PacketTraceNetSimulyzer, dlRxTput));
+            dlServerApp.Get(0)->TraceConnect("RxWithSeqTsSize",
+                                             "rx",
+                                             MakeBoundCallback(&PacketTraceNetSimulyzer, dlRxTput));
             dlUeTputCollection->Add(dlRxTput->GetSeries());
             dlRxTputCollection->Add(dlRxTput->GetSeries());
 
@@ -1851,17 +1858,17 @@ main(int argc, char* argv[])
             dlRxDelay->SetAttribute("Connection", StringValue("None"));
             dlRxDelay->GetXAxis()->SetAttribute("Name", StringValue("Time (s)"));
             dlRxDelay->GetYAxis()->SetAttribute("Name", StringValue("Packet delay (ms)"));
-            dlSeverApp.Get(0)->TraceConnectWithoutContext(
+            dlServerApp.Get(0)->TraceConnectWithoutContext(
                 "RxWithSeqTsSize",
                 MakeBoundCallback(&RxPacketTraceForDelayNetSimulyzer,
                                   dlRxDelay,
-                                  dlSeverApp.Get(0)->GetNode(),
+                                  dlServerApp.Get(0)->GetNode(),
                                   relaysIpv4AddressVector[ryIdx]));
-            dlSeverApp.Get(0)->TraceConnectWithoutContext(
+            dlServerApp.Get(0)->TraceConnectWithoutContext(
                 "RxWithSeqTsSize",
                 MakeBoundCallback(&CdfTraceForDelayNetSimulyzer,
                                   dlDelayEcdfRelays,
-                                  dlSeverApp.Get(0)->GetNode(),
+                                  dlServerApp.Get(0)->GetNode(),
                                   relaysIpv4AddressVector[ryIdx]));
 #endif
 
@@ -1915,17 +1922,17 @@ main(int argc, char* argv[])
 
             PacketSinkHelper ulPacketSinkHelper("ns3::UdpSocketFactory",
                                                 InetSocketAddress(Ipv4Address::GetAny(), ulPort));
-            ApplicationContainer ulSeverApp = ulPacketSinkHelper.Install(remoteHost);
-            serverApps.Add(ulSeverApp);
+            ApplicationContainer ulServerApp = ulPacketSinkHelper.Install(remoteHost);
+            serverApps.Add(ulServerApp);
 
 #ifdef HAS_NETSIMULYZER
             auto ulRxTput = CreateObject<netsimulyzer::ThroughputSink>(
                 orchestrator,
                 "Throughput - Relay UE - Rx - UL - Node " + std::to_string(nodeId));
             ulRxTput->GetSeries()->SetAttribute("Color", GetNextColor());
-            ulSeverApp.Get(0)->TraceConnect("RxWithSeqTsSize",
-                                            "rx",
-                                            MakeBoundCallback(&PacketTraceNetSimulyzer, ulRxTput));
+            ulServerApp.Get(0)->TraceConnect("RxWithSeqTsSize",
+                                             "rx",
+                                             MakeBoundCallback(&PacketTraceNetSimulyzer, ulRxTput));
             ulUeTputCollection->Add(ulRxTput->GetSeries());
             ulRxTputCollection->Add(ulRxTput->GetSeries());
 
@@ -1937,17 +1944,17 @@ main(int argc, char* argv[])
             ulRxDelay->SetAttribute("Connection", StringValue("None"));
             ulRxDelay->GetXAxis()->SetAttribute("Name", StringValue("Time (s)"));
             ulRxDelay->GetYAxis()->SetAttribute("Name", StringValue("Packet delay (ms)"));
-            ulSeverApp.Get(0)->TraceConnectWithoutContext(
+            ulServerApp.Get(0)->TraceConnectWithoutContext(
                 "RxWithSeqTsSize",
                 MakeBoundCallback(&RxPacketTraceForDelayNetSimulyzer,
                                   ulRxDelay,
-                                  ulSeverApp.Get(0)->GetNode(),
+                                  ulServerApp.Get(0)->GetNode(),
                                   remoteHostAddr));
-            ulSeverApp.Get(0)->TraceConnectWithoutContext(
+            ulServerApp.Get(0)->TraceConnectWithoutContext(
                 "RxWithSeqTsSize",
                 MakeBoundCallback(&CdfTraceForDelayNetSimulyzer,
                                   ulDelayEcdfRelays,
-                                  ulSeverApp.Get(0)->GetNode(),
+                                  ulServerApp.Get(0)->GetNode(),
                                   remoteHostAddr));
 #endif
 
@@ -1969,6 +1976,18 @@ main(int argc, char* argv[])
     clientApps.Stop(simTime);
     serverApps.Start(Seconds(1.0));
     serverApps.Stop(simTime);
+
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(gNbNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(inNetUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(relayUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(remoteUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(remoteHostContainer, randomStream);
+
     /******************** End Application configuration ************************/
 
     /************ SL traces database setup *************************************/

--- a/examples/nr-prose-l3-relay-on-off.cc
+++ b/examples/nr-prose-l3-relay-on-off.cc
@@ -827,6 +827,7 @@ main(int argc, char* argv[])
     bwp0->m_channelBandwidth = bandwidthCc0Bpw0;
     bwp0->m_lowerFrequency = bwp0->m_centralFrequency - bwp0->m_channelBandwidth / 2;
     bwp0->m_higherFrequency = bwp0->m_centralFrequency + bwp0->m_channelBandwidth / 2;
+    bwp0->m_scenario = BandwidthPartInfo::Scenario::RMa_LoS;
 
     cc0->AddBwp(std::move(bwp0));
 
@@ -836,6 +837,7 @@ main(int argc, char* argv[])
     bwp1->m_channelBandwidth = bandwidthCc0Bpw1;
     bwp1->m_lowerFrequency = bwp1->m_centralFrequency - bwp1->m_channelBandwidth / 2;
     bwp1->m_higherFrequency = bwp1->m_centralFrequency + bwp1->m_channelBandwidth / 2;
+    bwp0->m_scenario = BandwidthPartInfo::Scenario::RMa_LoS;
 
     cc0->AddBwp(std::move(bwp1));
 

--- a/examples/nr-prose-l3-relay.cc
+++ b/examples/nr-prose-l3-relay.cc
@@ -343,6 +343,7 @@ main(int argc, char* argv[])
     bwp0->m_channelBandwidth = bandwidthCc0Bpw0;
     bwp0->m_lowerFrequency = bwp0->m_centralFrequency - bwp0->m_channelBandwidth / 2;
     bwp0->m_higherFrequency = bwp0->m_centralFrequency + bwp0->m_channelBandwidth / 2;
+    bwp0->m_scenario = BandwidthPartInfo::Scenario::RMa_LoS;
 
     cc0->AddBwp(std::move(bwp0));
 
@@ -352,6 +353,7 @@ main(int argc, char* argv[])
     bwp1->m_channelBandwidth = bandwidthCc0Bpw1;
     bwp1->m_lowerFrequency = bwp1->m_centralFrequency - bwp1->m_channelBandwidth / 2;
     bwp1->m_higherFrequency = bwp1->m_centralFrequency + bwp1->m_channelBandwidth / 2;
+    bwp1->m_scenario = BandwidthPartInfo::Scenario::RMa_LoS;
 
     cc0->AddBwp(std::move(bwp1));
 

--- a/examples/nr-prose-l3-relay.cc
+++ b/examples/nr-prose-l3-relay.cc
@@ -599,12 +599,18 @@ main(int argc, char* argv[])
 
     // Set random streams
     int64_t randomStream = 1;
-    randomStream += nrHelper->AssignStreams(enbNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(inNetUeNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(relayUeNetDev, randomStream);
-    randomStream += nrSlHelper->AssignStreams(relayUeNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(remoteUeNetDev, randomStream);
-    randomStream += nrSlHelper->AssignStreams(remoteUeNetDev, randomStream);
+    const uint64_t streamIncrement = 1000;
+    nrHelper->AssignStreams(enbNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(inNetUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(relayUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrSlHelper->AssignStreams(relayUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(remoteUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrSlHelper->AssignStreams(remoteUeNetDev, randomStream);
 
     // create the internet and install the IP stack on the UEs
     // get SGW/PGW and create a single RemoteHost
@@ -774,6 +780,8 @@ main(int argc, char* argv[])
     // Random variable to randomize a bit start times of the client applications
     // to avoid simulation artifacts of all the TX UEs transmitting at the same time.
     Ptr<UniformRandomVariable> startTimeRnd = CreateObject<UniformRandomVariable>();
+    randomStream += streamIncrement;
+    startTimeRnd->SetStream(randomStream);
     startTimeRnd->SetAttribute("Min", DoubleValue(0));
     startTimeRnd->SetAttribute("Max", DoubleValue(0.1)); // seconds
 
@@ -983,6 +991,17 @@ main(int argc, char* argv[])
     serverApps.Stop(Seconds(simTime));
     clientApps.Stop(Seconds(simTime));
     /********* END In-network only applications configuration ******/
+
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(gNbNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(inNetUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(relayUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(remoteUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(remoteHostContainer, randomStream);
 
     /************ SL traces database setup *************************************/
     std::string exampleName = simTag + "-" + "nr-prose-l3-relay";

--- a/examples/nr-prose-network-coex.cc
+++ b/examples/nr-prose-network-coex.cc
@@ -591,10 +591,14 @@ main(int argc, char* argv[])
 
     // Set random streams
     int64_t randomStream = 1;
-    randomStream += nrHelper->AssignStreams(enbNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(inNetUeNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(slUeNetDev, randomStream);
-    randomStream += nrSlHelper->AssignStreams(slUeNetDev, randomStream);
+    const uint64_t streamIncrement = 1000;
+    nrHelper->AssignStreams(enbNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(inNetUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(slUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrSlHelper->AssignStreams(slUeNetDev, randomStream);
 
     // create the internet and install the IP stack on the UEs
     // get SGW/PGW and create a single RemoteHost
@@ -783,6 +787,8 @@ main(int argc, char* argv[])
     // Random variable to randomize a bit start times of the client applications
     // to avoid simulation artifacts of all the TX UEs transmitting at the same time.
     Ptr<UniformRandomVariable> startTimeRnd = CreateObject<UniformRandomVariable>();
+    randomStream += streamIncrement;
+    startTimeRnd->SetStream(randomStream);
     startTimeRnd->SetAttribute("Min", DoubleValue(0));
     startTimeRnd->SetAttribute("Max", DoubleValue(0.10));
     uint16_t slPort = 8000;
@@ -843,6 +849,15 @@ main(int argc, char* argv[])
     slServerApps.Start(Seconds(1.0));
     slServerApps.Stop(Seconds(simTime));
     /******************** End SL application configuration ************************/
+
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(gNbNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(inNetUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(slUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(remoteHostContainer, randomStream);
 
     /************ SL traces database setup *************************************/
     std::string exampleName = simTag + "-" + "nr-prose-network-coex";

--- a/examples/nr-prose-network-coex.cc
+++ b/examples/nr-prose-network-coex.cc
@@ -363,6 +363,7 @@ main(int argc, char* argv[])
     bwp0->m_channelBandwidth = bandwidthCc0Bpw0;
     bwp0->m_lowerFrequency = bwp0->m_centralFrequency - bwp0->m_channelBandwidth / 2;
     bwp0->m_higherFrequency = bwp0->m_centralFrequency + bwp0->m_channelBandwidth / 2;
+    bwp0->m_scenario = BandwidthPartInfo::Scenario::RMa_LoS;
 
     cc0->AddBwp(std::move(bwp0));
 
@@ -372,6 +373,7 @@ main(int argc, char* argv[])
     bwp1->m_channelBandwidth = bandwidthCc0Bpw1;
     bwp1->m_lowerFrequency = bwp1->m_centralFrequency - bwp1->m_channelBandwidth / 2;
     bwp1->m_higherFrequency = bwp1->m_centralFrequency + bwp1->m_channelBandwidth / 2;
+    bwp1->m_scenario = BandwidthPartInfo::Scenario::RMa_LoS;
 
     cc0->AddBwp(std::move(bwp1));
 

--- a/examples/nr-prose-unicast-l3-relay.cc
+++ b/examples/nr-prose-unicast-l3-relay.cc
@@ -716,12 +716,18 @@ main(int argc, char* argv[])
 
     // Set random streams
     int64_t randomStream = 1;
-    randomStream += nrHelper->AssignStreams(enbNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(inNetUeNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(relayUeNetDev, randomStream);
-    randomStream += nrSlHelper->AssignStreams(relayUeNetDev, randomStream);
-    randomStream += nrHelper->AssignStreams(slUeNetDev, randomStream);
-    randomStream += nrSlHelper->AssignStreams(slUeNetDev, randomStream);
+    const uint64_t streamIncrement = 1000;
+    nrHelper->AssignStreams(enbNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(inNetUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(relayUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrSlHelper->AssignStreams(relayUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrHelper->AssignStreams(slUeNetDev, randomStream);
+    randomStream += streamIncrement;
+    nrSlHelper->AssignStreams(slUeNetDev, randomStream);
 
     // create the internet and install the IP stack on the UEs
     // get SGW/PGW and create a single RemoteHost
@@ -1135,6 +1141,8 @@ main(int argc, char* argv[])
     // Random variable to randomize a bit start times of the client applications
     // to avoid simulation artifacts of all the TX UEs transmitting at the same time.
     Ptr<UniformRandomVariable> startTimeRnd = CreateObject<UniformRandomVariable>();
+    randomStream += streamIncrement;
+    startTimeRnd->SetStream(randomStream);
     startTimeRnd->SetAttribute("Min", DoubleValue(0));
     startTimeRnd->SetAttribute("Max", DoubleValue(0.10));
     uint16_t slPort = 8000;
@@ -1200,6 +1208,17 @@ main(int argc, char* argv[])
     slServerApps.Start(Seconds(1.0));
     slServerApps.Stop(Seconds(simTime));
     /******************** End SL application configuration ************************/
+
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(gNbNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(inNetUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(relayUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(slUeNodes, randomStream);
+    randomStream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(remoteHostContainer, randomStream);
 
     /******************* PC5-S messages tracing ********************************/
     AsciiTraceHelper ascii;

--- a/examples/nr-prose-unicast-l3-relay.cc
+++ b/examples/nr-prose-unicast-l3-relay.cc
@@ -448,6 +448,7 @@ main(int argc, char* argv[])
     bwp0->m_channelBandwidth = bandwidthCc0Bpw0;
     bwp0->m_lowerFrequency = bwp0->m_centralFrequency - bwp0->m_channelBandwidth / 2;
     bwp0->m_higherFrequency = bwp0->m_centralFrequency + bwp0->m_channelBandwidth / 2;
+    bwp0->m_scenario = BandwidthPartInfo::Scenario::RMa_LoS;
 
     cc0->AddBwp(std::move(bwp0));
 
@@ -457,6 +458,7 @@ main(int argc, char* argv[])
     bwp1->m_channelBandwidth = bandwidthCc0Bpw1;
     bwp1->m_lowerFrequency = bwp1->m_centralFrequency - bwp1->m_channelBandwidth / 2;
     bwp1->m_higherFrequency = bwp1->m_centralFrequency + bwp1->m_channelBandwidth / 2;
+    bwp1->m_scenario = BandwidthPartInfo::Scenario::RMa_LoS;
 
     cc0->AddBwp(std::move(bwp1));
 

--- a/examples/nr-prose-unicast-multi-link.cc
+++ b/examples/nr-prose-unicast-multi-link.cc
@@ -583,8 +583,10 @@ main(int argc, char* argv[])
      * Fix the random streams
      */
     int64_t stream = 1;
-    stream += nrHelper->AssignStreams(ueVoiceNetDev, stream);
-    stream += nrSlHelper->AssignStreams(ueVoiceNetDev, stream);
+    const uint64_t streamIncrement = 1000;
+    nrHelper->AssignStreams(ueVoiceNetDev, stream);
+    stream += streamIncrement;
+    nrSlHelper->AssignStreams(ueVoiceNetDev, stream);
 
     /*
      * Configure the IPv4 stack
@@ -681,6 +683,8 @@ main(int argc, char* argv[])
     // Random variable to randomize a bit start times of the client applications
     // to avoid simulation artifacts of all the TX UEs transmitting at the same time.
     Ptr<UniformRandomVariable> startTimeRnd = CreateObject<UniformRandomVariable>();
+    stream += streamIncrement;
+    startTimeRnd->SetStream(stream);
     startTimeRnd->SetAttribute("Min", DoubleValue(0));
     startTimeRnd->SetAttribute("Max", DoubleValue(0.10));
 
@@ -738,6 +742,9 @@ main(int argc, char* argv[])
     sidelinkSink.SetAttribute("EnableSeqTsSizeHeader", BooleanValue(true));
     serverApps = sidelinkSink.Install(ueVoiceContainer); // Installed in all UEs
     serverApps.Start(Seconds(2.0));
+
+    stream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(ueVoiceContainer, stream);
 
     /******************** End application configuration ************************/
 

--- a/examples/nr-prose-unicast-single-link.cc
+++ b/examples/nr-prose-unicast-single-link.cc
@@ -607,8 +607,10 @@ main(int argc, char* argv[])
      * Fix the random streams
      */
     int64_t stream = 1;
-    stream += nrHelper->AssignStreams(ueVoiceNetDev, stream);
-    stream += nrSlHelper->AssignStreams(ueVoiceNetDev, stream);
+    const uint64_t streamIncrement = 1000;
+    nrHelper->AssignStreams(ueVoiceNetDev, stream);
+    stream += streamIncrement;
+    nrSlHelper->AssignStreams(ueVoiceNetDev, stream);
 
     /*
      * Configure the IPv4 stack
@@ -711,6 +713,9 @@ main(int argc, char* argv[])
     sidelinkSink.SetAttribute("EnableSeqTsSizeHeader", BooleanValue(true));
     serverApps = sidelinkSink.Install(ueVoiceContainer.Get(1)); // Installed in UE2
     serverApps.Start(Seconds(2.0));
+
+    stream += streamIncrement;
+    ApplicationHelper::AssignStreamsToAllApps(ueVoiceContainer, stream);
 
     /******************** End application configuration ************************/
 

--- a/model/nr-sl-ue-prose-relay-selection-algorithm.cc
+++ b/model/nr-sl-ue-prose-relay-selection-algorithm.cc
@@ -35,13 +35,7 @@
 
 #include "nr-sl-ue-prose-relay-selection-algorithm.h"
 
-#include <ns3/abort.h>
-#include <ns3/fatal-error.h>
 #include <ns3/log.h>
-#include <ns3/object-factory.h>
-#include <ns3/object-map.h>
-#include <ns3/pointer.h>
-#include <ns3/simulator.h>
 
 namespace ns3
 {
@@ -50,19 +44,19 @@ NS_LOG_COMPONENT_DEFINE("NrSlUeProseRelaySelectionAlgorithm");
 NS_OBJECT_ENSURE_REGISTERED(NrSlUeProseRelaySelectionAlgorithm);
 
 TypeId
-NrSlUeProseRelaySelectionAlgorithm::GetTypeId(void)
+NrSlUeProseRelaySelectionAlgorithm::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::NrSlUeProseRelaySelectionAlgorithm").SetParent<Object>().SetGroupName("Nr");
     return tid;
 }
 
-NrSlUeProseRelaySelectionAlgorithm::NrSlUeProseRelaySelectionAlgorithm(void)
+NrSlUeProseRelaySelectionAlgorithm::NrSlUeProseRelaySelectionAlgorithm()
 {
     NS_LOG_FUNCTION(this);
 }
 
-NrSlUeProseRelaySelectionAlgorithm::~NrSlUeProseRelaySelectionAlgorithm(void)
+NrSlUeProseRelaySelectionAlgorithm::~NrSlUeProseRelaySelectionAlgorithm()
 {
     NS_LOG_FUNCTION(this);
 }
@@ -70,7 +64,7 @@ NrSlUeProseRelaySelectionAlgorithm::~NrSlUeProseRelaySelectionAlgorithm(void)
 NS_OBJECT_ENSURE_REGISTERED(NrSlUeProseRelaySelectionAlgorithmFirstAvailable);
 
 TypeId
-NrSlUeProseRelaySelectionAlgorithmFirstAvailable::GetTypeId(void)
+NrSlUeProseRelaySelectionAlgorithmFirstAvailable::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::NrSlUeProseRelaySelectionAlgorithmFirstAvailable")
                             .SetParent<NrSlUeProseRelaySelectionAlgorithm>()
@@ -79,15 +73,14 @@ NrSlUeProseRelaySelectionAlgorithmFirstAvailable::GetTypeId(void)
     return tid;
 }
 
-NrSlUeProseRelaySelectionAlgorithmFirstAvailable::NrSlUeProseRelaySelectionAlgorithmFirstAvailable(
-    void)
+NrSlUeProseRelaySelectionAlgorithmFirstAvailable::NrSlUeProseRelaySelectionAlgorithmFirstAvailable()
     : NrSlUeProseRelaySelectionAlgorithm()
 {
     NS_LOG_FUNCTION(this);
 }
 
-NrSlUeProseRelaySelectionAlgorithmFirstAvailable::~NrSlUeProseRelaySelectionAlgorithmFirstAvailable(
-    void)
+NrSlUeProseRelaySelectionAlgorithmFirstAvailable::
+    ~NrSlUeProseRelaySelectionAlgorithmFirstAvailable()
 {
     NS_LOG_FUNCTION(this);
 }
@@ -98,14 +91,23 @@ NrSlUeProseRelaySelectionAlgorithmFirstAvailable::SelectRelay(
 {
     NS_LOG_FUNCTION(this << discoveredRelays.size());
 
-    NS_LOG_DEBUG("Selection algorithm: first available relay");
-    return discoveredRelays.at(0);
+    if (!discoveredRelays.empty())
+    {
+        NS_LOG_INFO(
+            "Selection algorithm: first available relay L2Id: " << discoveredRelays.at(0).l2Id);
+        return discoveredRelays.at(0);
+    }
+    else
+    {
+        NS_LOG_INFO("Selection algorithm: no available relays");
+        return NrSlUeProse::RelayInfo();
+    }
 }
 
 NS_OBJECT_ENSURE_REGISTERED(NrSlUeProseRelaySelectionAlgorithmRandom);
 
 TypeId
-NrSlUeProseRelaySelectionAlgorithmRandom::GetTypeId(void)
+NrSlUeProseRelaySelectionAlgorithmRandom::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::NrSlUeProseRelaySelectionAlgorithmRandom")
                             .SetParent<NrSlUeProseRelaySelectionAlgorithm>()
@@ -114,14 +116,14 @@ NrSlUeProseRelaySelectionAlgorithmRandom::GetTypeId(void)
     return tid;
 }
 
-NrSlUeProseRelaySelectionAlgorithmRandom::NrSlUeProseRelaySelectionAlgorithmRandom(void)
-    : NrSlUeProseRelaySelectionAlgorithm(),
-      m_rand(CreateObject<UniformRandomVariable>())
+NrSlUeProseRelaySelectionAlgorithmRandom::NrSlUeProseRelaySelectionAlgorithmRandom()
+    : NrSlUeProseRelaySelectionAlgorithm()
 {
     NS_LOG_FUNCTION(this);
+    m_rand = CreateObject<UniformRandomVariable>();
 }
 
-NrSlUeProseRelaySelectionAlgorithmRandom::~NrSlUeProseRelaySelectionAlgorithmRandom(void)
+NrSlUeProseRelaySelectionAlgorithmRandom::~NrSlUeProseRelaySelectionAlgorithmRandom()
 {
     NS_LOG_FUNCTION(this);
 }
@@ -140,22 +142,28 @@ NrSlUeProseRelaySelectionAlgorithmRandom::SelectRelay(
 {
     NS_LOG_FUNCTION(this << discoveredRelays.size());
 
-    NS_LOG_DEBUG("Selection algorithm: random relay");
-    uint32_t i = m_rand->GetInteger(0, discoveredRelays.size() - 1);
-
-    return discoveredRelays.at(i);
+    if (!discoveredRelays.empty())
+    {
+        uint32_t i = m_rand->GetInteger(0, discoveredRelays.size() - 1);
+        NS_LOG_INFO("Selection algorithm: random relay L2Id: " << discoveredRelays.at(i).l2Id);
+        return discoveredRelays.at(i);
+    }
+    else
+    {
+        NS_LOG_INFO("Selection algorithm: no available relays");
+        return NrSlUeProse::RelayInfo();
+    }
 }
 
 void
-NrSlUeProseRelaySelectionAlgorithmRandom::DoDispose(void)
+NrSlUeProseRelaySelectionAlgorithmRandom::DoDispose()
 {
-    m_rand = nullptr;
 }
 
 NS_OBJECT_ENSURE_REGISTERED(NrSlUeProseRelaySelectionAlgorithmMaxRsrp);
 
 TypeId
-NrSlUeProseRelaySelectionAlgorithmMaxRsrp::GetTypeId(void)
+NrSlUeProseRelaySelectionAlgorithmMaxRsrp::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::NrSlUeProseRelaySelectionAlgorithmMaxRsrp")
                             .SetParent<NrSlUeProseRelaySelectionAlgorithm>()
@@ -164,13 +172,13 @@ NrSlUeProseRelaySelectionAlgorithmMaxRsrp::GetTypeId(void)
     return tid;
 }
 
-NrSlUeProseRelaySelectionAlgorithmMaxRsrp::NrSlUeProseRelaySelectionAlgorithmMaxRsrp(void)
+NrSlUeProseRelaySelectionAlgorithmMaxRsrp::NrSlUeProseRelaySelectionAlgorithmMaxRsrp()
     : NrSlUeProseRelaySelectionAlgorithm()
 {
     NS_LOG_FUNCTION(this);
 }
 
-NrSlUeProseRelaySelectionAlgorithmMaxRsrp::~NrSlUeProseRelaySelectionAlgorithmMaxRsrp(void)
+NrSlUeProseRelaySelectionAlgorithmMaxRsrp::~NrSlUeProseRelaySelectionAlgorithmMaxRsrp()
 {
     NS_LOG_FUNCTION(this);
 }
@@ -181,34 +189,31 @@ NrSlUeProseRelaySelectionAlgorithmMaxRsrp::SelectRelay(
 {
     NS_LOG_FUNCTION(this << discoveredRelays.size());
 
-    NS_LOG_DEBUG("Selection algorithm: relay with best RSRP value");
-
     NrSlUeProse::RelayInfo relay;
-    relay.rsrp = (-1) * std::numeric_limits<double>::infinity();
     bool found = false;
     for (uint32_t i = 0; i < discoveredRelays.size(); ++i)
     {
         NrSlUeProse::RelayInfo relayIt = discoveredRelays.at(i);
         if ((relayIt.rsrp > relay.rsrp) && (relayIt.eligible == true))
         {
-            NS_LOG_DEBUG("Found at least one eligible relay!");
             relay.l2Id = relayIt.l2Id;
             relay.relayCode = relayIt.relayCode;
             relay.rsrp = relayIt.rsrp;
             relay.eligible = relayIt.eligible;
             found = true;
+            NS_LOG_DEBUG("Selection algorithm: found candidate L2Id " << relay.l2Id << " with RSRP "
+                                                                      << relay.rsrp);
         }
     }
     if (!found)
     {
-        NS_LOG_DEBUG("No eligible relay is found!");
-        relay.l2Id = 0;
-        relay.relayCode = 0;
-        double inf = std::numeric_limits<double>::infinity();
-        relay.rsrp = (-1) * inf;
-        relay.eligible = false;
+        NS_LOG_INFO("Selection algorithm: no eligible relay was found");
     }
-
+    else
+    {
+        NS_LOG_INFO("Selection algorithm: selected candidate L2Id " << relay.l2Id << " with RSRP "
+                                                                    << relay.rsrp);
+    }
     return relay;
 }
 

--- a/model/nr-sl-ue-prose-relay-selection-algorithm.h
+++ b/model/nr-sl-ue-prose-relay-selection-algorithm.h
@@ -40,8 +40,6 @@
 
 #include <ns3/object.h>
 #include <ns3/random-variable-stream.h>
-#include <ns3/tag.h>
-#include <ns3/timer.h>
 
 #include <vector>
 
@@ -49,7 +47,7 @@ namespace ns3
 {
 
 /**
- * \ingroup nr
+ * \ingroup nr-prose
  *
  * \brief Base class for NR ProSe Relay Selection Algorithms
  *
@@ -61,9 +59,9 @@ namespace ns3
 class NrSlUeProseRelaySelectionAlgorithm : public Object
 {
   public:
-    NrSlUeProseRelaySelectionAlgorithm(void);
-    virtual ~NrSlUeProseRelaySelectionAlgorithm(void);
-    static TypeId GetTypeId(void);
+    NrSlUeProseRelaySelectionAlgorithm();
+    ~NrSlUeProseRelaySelectionAlgorithm() override;
+    static TypeId GetTypeId();
 
     /**
      * \brief Selects a relay from the available list.
@@ -78,54 +76,40 @@ class NrSlUeProseRelaySelectionAlgorithm : public Object
 }; // end of NrSlUeProseRelaySelectionAlgorithm
 
 /**
- * \ingroup nr
+ * \ingroup nr-prose
  *
  * \brief Implements the first available relay selection algorithm
  */
 class NrSlUeProseRelaySelectionAlgorithmFirstAvailable : public NrSlUeProseRelaySelectionAlgorithm
 {
   public:
-    NrSlUeProseRelaySelectionAlgorithmFirstAvailable(void);
-    virtual ~NrSlUeProseRelaySelectionAlgorithmFirstAvailable(void);
-    static TypeId GetTypeId(void);
+    NrSlUeProseRelaySelectionAlgorithmFirstAvailable();
+    ~NrSlUeProseRelaySelectionAlgorithmFirstAvailable() override;
+    static TypeId GetTypeId();
 
-    /**
-     * \brief Select first available relay.
-     *
-     * \param discoveredRelays List of discovered relays
-     *
-     * \returns The newly selected relay.
-     */
-    virtual NrSlUeProse::RelayInfo SelectRelay(
+    NrSlUeProse::RelayInfo SelectRelay(
         std::vector<NrSlUeProse::RelayInfo> discoveredRelays) override;
 
 }; // end of NrSlUeProseRelaySelectionAlgorithmFirstAvailable
 
 /**
- * \ingroup nr
+ * \ingroup nr-prose
  *
  * \brief Implements the random relay selection algorithm
  */
 class NrSlUeProseRelaySelectionAlgorithmRandom : public NrSlUeProseRelaySelectionAlgorithm
 {
   public:
-    NrSlUeProseRelaySelectionAlgorithmRandom(void);
-    virtual ~NrSlUeProseRelaySelectionAlgorithmRandom(void);
-    static TypeId GetTypeId(void);
+    NrSlUeProseRelaySelectionAlgorithmRandom();
+    ~NrSlUeProseRelaySelectionAlgorithmRandom() override;
+    static TypeId GetTypeId();
     virtual int64_t AssignStreams(int64_t stream);
 
-    /**
-     * \brief Select random relay.
-     *
-     * \param discoveredRelays List of discovered relays
-     *
-     * \returns The newly selected relay.
-     */
-    virtual NrSlUeProse::RelayInfo SelectRelay(
+    NrSlUeProse::RelayInfo SelectRelay(
         std::vector<NrSlUeProse::RelayInfo> discoveredRelays) override;
 
   protected:
-    virtual void DoDispose(void) override;
+    void DoDispose() override;
 
   private:
     Ptr<UniformRandomVariable> m_rand; //!< The uniform random variable
@@ -133,25 +117,22 @@ class NrSlUeProseRelaySelectionAlgorithmRandom : public NrSlUeProseRelaySelectio
 }; // end of NrSlUeProseRelaySelectionAlgorithmRandom
 
 /**
- * \ingroup nr
+ * \ingroup nr-prose
  *
  * \brief Implements the max RSRP relay selection algorithm
+ *
+ * The RelayInfo with the maximum RSRP value, considering only those that
+ * are set to 'eligible', will be returned by SelectRelay().  If no eligible
+ * relays are found, SelectRelay() will return an uninitialized RelayInfo.
  */
 class NrSlUeProseRelaySelectionAlgorithmMaxRsrp : public NrSlUeProseRelaySelectionAlgorithm
 {
   public:
-    NrSlUeProseRelaySelectionAlgorithmMaxRsrp(void);
-    virtual ~NrSlUeProseRelaySelectionAlgorithmMaxRsrp(void);
-    static TypeId GetTypeId(void);
+    NrSlUeProseRelaySelectionAlgorithmMaxRsrp();
+    ~NrSlUeProseRelaySelectionAlgorithmMaxRsrp() override;
+    static TypeId GetTypeId();
 
-    /**
-     * \brief Select the relay with the max RSRP.
-     *
-     * \param discoveredRelays List of discovered relays
-     *
-     * \returns The newly selected relay.
-     */
-    virtual NrSlUeProse::RelayInfo SelectRelay(
+    NrSlUeProse::RelayInfo SelectRelay(
         std::vector<NrSlUeProse::RelayInfo> discoveredRelays) override;
 
 }; // end of NrSlUeProseRelaySelectionAlgorithmMaxRsrp

--- a/model/nr-sl-ue-prose.cc
+++ b/model/nr-sl-ue-prose.cc
@@ -853,12 +853,12 @@ NrSlUeProse::SelectRelay()
     else
     {
         // Check if the list of discovered relays is empty
-        if (m_discoveredRelaysList.size() != 0)
+        if (m_discoveredRelaysList.empty())
         {
             newRelay = m_relaySelectionAlgorithm->SelectRelay(m_discoveredRelaysList);
 
-            // Check if it is an eligibale relay
-            if (newRelay.l2Id != 0)
+            // Check if it is an eligible relay
+            if (newRelay.l2Id != std::numeric_limits<uint32_t>::max())
             {
                 // Trace the attempt to change a selected relay
                 m_relaySelectionTrace(m_l2Id,
@@ -933,7 +933,7 @@ NrSlUeProse::SelectRelay()
             // No relay gets selected: check if we have an ongoing connection and release it
             else
             {
-                if (m_currentSelectedRelay.l2Id != 0)
+                if (m_currentSelectedRelay.l2Id != std::numeric_limits<uint32_t>::max())
                 {
                     // Get existing link
                     auto it = m_unicastDirectLinks.find(m_currentSelectedRelay.l2Id);

--- a/model/nr-sl-ue-prose.h
+++ b/model/nr-sl-ue-prose.h
@@ -48,7 +48,7 @@
 
 #include <unordered_map>
 
-//#include <ns3/nr-sl-prose-relay-handle.h>
+// #include <ns3/nr-sl-prose-relay-handle.h>
 
 namespace ns3
 {
@@ -129,13 +129,13 @@ class NrSlUeProse : public NrSlUeService
         uint32_t dstL2Id;     ///< destination L2 ID
     };
 
-    ///< Information of discovered relays
+    ///< Information about discovered relays
     struct RelayInfo
     {
-        uint32_t l2Id;
-        uint32_t relayCode;
-        double rsrp;
-        bool eligible;
+        uint32_t l2Id{std::numeric_limits<uint32_t>::max()};      ///< layer 2 ID
+        uint32_t relayCode{std::numeric_limits<uint32_t>::max()}; ///< relay code
+        double rsrp{-std::numeric_limits<double>::infinity()};    ///< RSRP
+        bool eligible{false}; ///< whether relay meets RSRP threshold/hysteresis criteria
     };
 
   protected:


### PR DESCRIPTION
1)  NrSlUeProse: Add logging to selection algorithm, and clang-tidy cleanup

The above commit was useful to check the relay selection program operation.

2) Update random variable stream handling in examples

Avoid chaining the stream configuration output from one call to AssignStreams() to the next.  This avoids some possible changes downstream when a change is made earlier in the program.  Also, this is the result of auditing all example programs to make sure that every random variable has an assigned stream number.  Similar changes are coming to the nr and ns-3-dev in the near future.

3)  Change all 3GPP channel conditions to line-of-sight

Part of the unexpected behavior of the l3 relay selection program was that some UEs were classified as non-line-of sight (randomly) so they could be shut out of the relay selection for certain random seeds.  Since the channel condition variation is not really relevant to these examples, I propose to make all of the 3GPP (RMa/UMa) models be configured as line-of-sight only.